### PR TITLE
Preloading theme files to prevent delay in loading themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,13 @@
 	<link href="https://fonts.googleapis.com/css2?family=Russo+One&display=swap" rel="stylesheet">
 
 	<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&family=Russo+One&display=swap" rel="stylesheet">
-
+	
+	<!-- Preloading the css variable files to prevent the delay in changing theme when the site is first loaded -->
+	<link rel="stylesheet" type="text/css" href="purple.css">
+	<link rel="stylesheet" type="text/css" href="green.css">
+	<link rel="stylesheet" type="text/css" href="blue.css">
+	
+	
 	<link rel="stylesheet" type="text/css" href="default.css">
 	<link id="theme-style" rel="stylesheet" type="text/css" href="">
 </head>


### PR DESCRIPTION
I've just quickly fixed an issue, now if you load the site first time throttling a slow connection, (or in a private browser window), the theme will instantly change and will take no delay for loading the whole page, this is a quick fix for slow connections in general and the UX.